### PR TITLE
script cleanup support (newlines now amended)

### DIFF
--- a/src/Phantom.Core/BuildRunner.cs
+++ b/src/Phantom.Core/BuildRunner.cs
@@ -70,6 +70,7 @@ namespace Phantom.Core {
 			var script = GenerateBuildScript(options.File);
 			script.Log = Log;
 			script.ExecuteTargets(options.TargetNames.ToArray());
+			script.ExecuteCleanups();
 		}
 
 		public void OutputTargets(PhantomOptions options) {

--- a/src/Phantom.Core/Cleanup.cs
+++ b/src/Phantom.Core/Cleanup.cs
@@ -1,0 +1,41 @@
+#region License
+
+// Copyright Jeremy Skinner (http://www.jeremyskinner.co.uk) and Contributors
+// 
+// Licensed under the Microsoft Public License. You may
+// obtain a copy of the license at:
+// 
+// http://www.microsoft.com/opensource/licenses.mspx
+// 
+// By using this source code in any fashion, you are agreeing
+// to be bound by the terms of the Microsoft Public License.
+// 
+// You must not remove this notice, or any other, from this software.
+
+#endregion
+
+namespace Phantom.Core {
+	using System;
+
+	public class Cleanup {
+		readonly Action block;
+		readonly ScriptModel parentScript;
+
+
+		public Cleanup(string name, Action block, string description, ScriptModel parentScript) {
+			Name = name;
+			Description = description;
+			this.block = block;
+			this.parentScript = parentScript;
+		}
+
+		public string Name { get; private set; }
+		public string Description { get; private set; }
+
+		public void Execute() {
+			if (block != null) {
+				block();
+			}
+		}
+	}
+}

--- a/src/Phantom.Core/Phantom.Core.csproj
+++ b/src/Phantom.Core/Phantom.Core.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Builtins\TestRunner.cs" />
     <Compile Include="Builtins\XSLT.cs" />
     <Compile Include="Builtins\XUnit.cs" />
+    <Compile Include="Cleanup.cs" />
     <Compile Include="ExcludeFromCoverageAttribute.cs" />
     <Compile Include="IDslFactory.cs" />
     <Compile Include="Builtins\IOFunctions.cs" />

--- a/src/Phantom.DSL.Boo/Language/ExpressionToCleanupNameStep.cs
+++ b/src/Phantom.DSL.Boo/Language/ExpressionToCleanupNameStep.cs
@@ -1,0 +1,38 @@
+#region License
+
+// Copyright Jeremy Skinner (http://www.jeremyskinner.co.uk) and Contributors
+// 
+// Licensed under the Microsoft Public License. You may
+// obtain a copy of the license at:
+// 
+// http://www.microsoft.com/opensource/licenses.mspx
+// 
+// By using this source code in any fashion, you are agreeing
+// to be bound by the terms of the Microsoft Public License.
+// 
+// You must not remove this notice, or any other, from this software.
+
+#endregion
+
+namespace Phantom.Core.Language {
+	using Boo.Lang.Compiler.Ast;
+	using Boo.Lang.Compiler.Steps;
+
+	public class ExpressionToCleanupNameStep : AbstractTransformerCompilerStep {
+		public override void Run() {
+			Visit(CompileUnit);
+		}
+
+		public override void OnMemberReferenceExpression(MemberReferenceExpression node) {
+			if (PhantomDslEngine.IsCleanupMethod(node.ParentNode)) {
+				ReplaceCurrentNode(new StringLiteralExpression(node.ToCodeString()));
+			}
+		}
+
+		public override void OnReferenceExpression(ReferenceExpression node) {
+			if (PhantomDslEngine.IsCleanupMethod(node.ParentNode)) {
+				ReplaceCurrentNode(new StringLiteralExpression(node.Name));
+			}
+		}
+	}
+}

--- a/src/Phantom.DSL.Boo/Phantom.DSL.Boo.csproj
+++ b/src/Phantom.DSL.Boo/Phantom.DSL.Boo.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Integration\ITaskImportBuilder.cs" />
     <Compile Include="Integration\TaskImportStep.cs" />
     <Compile Include="Language\AutoRunAllRunnablesStep.cs" />
+    <Compile Include="Language\ExpressionToCleanupNameStep.cs" />
     <Compile Include="Language\ExpressionToCallTargetNameStep.cs" />
     <Compile Include="Language\ExpressionToDependencyNamesStep.cs" />
     <Compile Include="Language\ExpressionToTargetNameStep.cs" />

--- a/src/Phantom.DSL.Boo/PhantomBase.cs
+++ b/src/Phantom.DSL.Boo/PhantomBase.cs
@@ -37,6 +37,17 @@ namespace Phantom.Core {
 			currentDescription = null;
 		}
 
+		public void cleanup(string name, Action block){
+			model.AddCleanup(name, block, currentDescription);
+			currentDescription = null;
+		}
+
+		public void cleanup( Action block)
+		{
+			model.AddCleanup(null, block, currentDescription);
+			currentDescription = null;
+		}
+
 		public abstract void Execute();
 
 		public ScriptModel Model {

--- a/src/Phantom.DSL.Boo/PhantomDslEngine.cs
+++ b/src/Phantom.DSL.Boo/PhantomDslEngine.cs
@@ -43,6 +43,7 @@ namespace Phantom.Core {
 				steps.Add(new UnescapeNamesStep());
 				steps.Add(new ExpressionToTargetNameStep());
 				steps.Add(new ExpressionToDependencyNamesStep());
+				steps.Add(new ExpressionToCleanupNameStep());
 				steps.Add(new ExpressionToCallTargetNameStep());
 				steps.Add(new AutoReferenceFilesCompilerStep());
 				steps.Add(new TaskImportStep(importBuilders.ToArray()));
@@ -91,6 +92,16 @@ namespace Phantom.Core {
 		public static bool IsTargetMethod(Node node) {
 			var macro = node as MacroStatement;
 			if (macro != null && macro.Name == "target") {
+				return true;
+			}
+			return false;
+		}
+
+		public static bool IsCleanupMethod(Node node)
+		{
+			var macro = node as MacroStatement;
+			if (macro != null && macro.Name == "cleanup")
+			{
 				return true;
 			}
 			return false;

--- a/src/Phantom.Tests/DslTester.cs
+++ b/src/Phantom.Tests/DslTester.cs
@@ -15,6 +15,7 @@
 #endregion
 
 namespace Phantom.Tests {
+	using System;
 	using System.Linq;
 	using Core;
 	using NUnit.Framework;
@@ -91,6 +92,46 @@ namespace Phantom.Tests {
 			executionSequence.Count.ShouldEqual(2);
 			executionSequence[0].Name.ShouldEqual("compile");
 			executionSequence[1].Name.ShouldEqual("oneDependency");
+		}
+
+		[Test]
+		public void Executes_cleanup() {
+			ScriptFile = "Scripts/Cleanups.boo";
+			Execute("works");
+			var expected = @"works:
+works
+
+cleanup:
+anonymous cleanup #1
+
+cleanup another:
+another cleanup
+
+cleanup:
+anonymous cleanup #2
+
+";
+			AssertOutput(expected.Split(new[] {System.Environment.NewLine}, StringSplitOptions.None));
+		}
+
+		[Test]
+		public void Executes_cleanup_even_if_task_fails() {
+			ScriptFile = "Scripts/Cleanups.boo";
+			Execute("throws");
+			var expected = @"throws:
+throws
+
+cleanup:
+anonymous cleanup #1
+
+cleanup another:
+another cleanup
+
+cleanup:
+anonymous cleanup #2
+
+";
+			AssertOutput(expected.Split(new[] {System.Environment.NewLine}, StringSplitOptions.None));
 		}
 	}
 }

--- a/src/Phantom.Tests/Phantom.Tests.csproj
+++ b/src/Phantom.Tests/Phantom.Tests.csproj
@@ -99,6 +99,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
+    <None Include="Scripts\Cleanups.boo">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Scripts\CSharpSimple.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Phantom.Tests/Scripts/Cleanups.boo
+++ b/src/Phantom.Tests/Scripts/Cleanups.boo
@@ -1,0 +1,15 @@
+﻿target works:
+	print "works"
+	
+target throws:
+	print "throws"
+
+cleanup:
+	print "anonymous cleanup #1"
+
+cleanup another:
+	print "another cleanup"
+
+cleanup:
+	print "anonymous cleanup #2"
+


### PR DESCRIPTION
allow scripts to perform cleanup tasks even if a target has failed

e.g. shut down services (like a profiler, DB, http server) etc.

allow multiple cleanup calls
1. for the sake of includes - each could add its own cleanup
2. easier to have cleanup tasks not depend on each other - thus if one fail the others still run

It was a must on a project Im working on now, with a complex build setup
our way around it for now is to have a global failed=false var, and all targets try-except to set it to true, and check it at the begin to bypass (except for a target named cleanup that never bypass).
