### PR TITLE
Simplified the condition

### DIFF
--- a/src/Phantom.Core/Options.cs
+++ b/src/Phantom.Core/Options.cs
@@ -189,7 +189,7 @@ namespace Mono.Options
 
 		private static int GetNextWidth (IEnumerator<int> ewidths, int curWidth, ref bool? eValid)
 		{
-			if (!eValid.HasValue || (eValid.HasValue && eValid.Value)) {
+			if (!eValid.HasValue || eValid.Value) {
 				curWidth = (eValid = ewidths.MoveNext ()).Value ? ewidths.Current : curWidth;
 				// '.' is any character, - is for a continuation
 				const string minWidth = ".-";


### PR DESCRIPTION
Such expressions can always be simplified, refer to the following chain of transformations:

```cs
str == null || (str != null && str == "");
(str == null || str != null) && (str == null || str == ""); // Distributive property 
true && (str == null || str == ""); // (a || !a) == true 
str == null || str == ""; // true && b == b 
```

The issue was found by [CodeRush for Roslyn](https://marketplace.visualstudio.com/items?itemName=DevExpress.CodeRushforRoslyn).